### PR TITLE
add Cuda 9.0 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,27 +247,33 @@ add_custom_command(
 set(GPU_CODE modelHandler_OpenCL.cl.h)
 
 if(CUDA_FOUND)
-	add_custom_command(
-		OUTPUT modelHandler_CUDA.ptx20.h
-		COMMAND ${CONV_EXE} modelHandler_CUDA.ptx20 modelHandler_CUDA.ptx20.h str
-		DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/modelHandler_CUDA.ptx20 conv
-	)
-	add_custom_command(
-		OUTPUT modelHandler_CUDA.ptx30.h
-		COMMAND ${CONV_EXE} modelHandler_CUDA.ptx30 modelHandler_CUDA.ptx30.h str
-		DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/modelHandler_CUDA.ptx30 conv
-	)
-	add_custom_command(
-		OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/modelHandler_CUDA.ptx20
-		COMMAND ${CUDA_NVCC_EXECUTABLE} ${CUDA_NVCC_FLAGS} -arch=sm_20 -ptx -o ${CMAKE_CURRENT_BINARY_DIR}/modelHandler_CUDA.ptx20 ${CMAKE_CURRENT_SOURCE_DIR}/src/modelHandler_CUDA.cu
-		DEPENDS src/modelHandler_CUDA.cu
-	)
-	add_custom_command(
-		OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/modelHandler_CUDA.ptx30
-		COMMAND ${CUDA_NVCC_EXECUTABLE} ${CUDA_NVCC_FLAGS} -arch=sm_30 -ptx -o ${CMAKE_CURRENT_BINARY_DIR}/modelHandler_CUDA.ptx30 ${CMAKE_CURRENT_SOURCE_DIR}/src/modelHandler_CUDA.cu
-		DEPENDS src/modelHandler_CUDA.cu
-	)
-	set(GPU_CODE ${GPU_CODE} modelHandler_CUDA.ptx30.h modelHandler_CUDA.ptx20.h)
+    if (CUDA_VERSION_MAJOR LESS 9)
+        add_custom_command(
+            OUTPUT modelHandler_CUDA.ptx20.h
+            COMMAND ${CONV_EXE} modelHandler_CUDA.ptx20 modelHandler_CUDA.ptx20.h str
+            DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/modelHandler_CUDA.ptx20 conv
+        )
+        add_custom_command(
+            OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/modelHandler_CUDA.ptx20
+            COMMAND ${CUDA_NVCC_EXECUTABLE} ${CUDA_NVCC_FLAGS} -arch=sm_20 -ptx -o ${CMAKE_CURRENT_BINARY_DIR}/modelHandler_CUDA.ptx20 ${CMAKE_CURRENT_SOURCE_DIR}/src/modelHandler_CUDA.cu
+            DEPENDS src/modelHandler_CUDA.cu
+        )
+    endif()
+    add_custom_command(
+        OUTPUT modelHandler_CUDA.ptx30.h
+        COMMAND ${CONV_EXE} modelHandler_CUDA.ptx30 modelHandler_CUDA.ptx30.h str
+        DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/modelHandler_CUDA.ptx30 conv
+    )
+    add_custom_command(
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/modelHandler_CUDA.ptx30
+        COMMAND ${CUDA_NVCC_EXECUTABLE} ${CUDA_NVCC_FLAGS} -arch=sm_30 -ptx -o ${CMAKE_CURRENT_BINARY_DIR}/modelHandler_CUDA.ptx30 ${CMAKE_CURRENT_SOURCE_DIR}/src/modelHandler_CUDA.cu
+        DEPENDS src/modelHandler_CUDA.cu
+    )
+    if (CUDA_VERSION_MAJOR LESS 9)
+        set(GPU_CODE ${GPU_CODE} modelHandler_CUDA.ptx30.h modelHandler_CUDA.ptx20.h)
+    else()
+        set(GPU_CODE ${GPU_CODE} modelHandler_CUDA.ptx30.h)
+    endif()
 endif()
 
 add_custom_target(gensrcs ALL DEPENDS ${GPU_CODE})

--- a/src/modelHandler_CUDA.cpp
+++ b/src/modelHandler_CUDA.cpp
@@ -15,9 +15,12 @@ static void *handle;
 #endif
 
 #ifdef HAVE_CUDA
+#include <cuda_runtime_api.h>
+#if CUDART_VERSION < 9000
 static const char prog20[] = 
 #include "modelHandler_CUDA.ptx20.h"
 	;
+#endif // CUDART_VERSION < 9000
 static const char prog30[] = 
 #include "modelHandler_CUDA.ptx30.h"
 	;
@@ -136,10 +139,12 @@ initCUDA(ComputeEnv *env, int dev_id)
 		return false;
 	}
 
-	const char *prog = prog20;
-	if (cap_major >= 3) {
-		prog = prog30;
+	const char *prog = prog30;
+#if CUDART_VERSION < 9000
+	if (cap_major < 3) {
+		prog = prog20;
 	}
+#endif
 
 	r = cuStreamCreate(&stream, 0);
 	if (r != CUDA_SUCCESS) {

--- a/src/w2xconv.cpp
+++ b/src/w2xconv.cpp
@@ -1173,7 +1173,7 @@ read_int2(FILE *fp) {
 
 //This checks if the file type is png, it defalts to the user inputted bkgd_colour otherwise.
 //The returning bool is whether the function excecuted successfully or not.
-void get_png_background_colour(FILE *png_fp, bool *png_rgb, struct float3 *bkgd_colour){
+void get_png_background_colour(FILE *png_fp, bool *png_rgb, struct w2xconv_rgb_float3 *bkgd_colour){
 	*png_rgb = false;
 	//png file signature
 	const static unsigned char png[] = {0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A};
@@ -1288,7 +1288,7 @@ w2xconv_convert_file(struct W2XConv *conv,
 	bool png_rgb;
 	//Background colour
 	//float3 background(1.0f, 1.0f, 1.0f);
-	float3 background;
+	struct w2xconv_rgb_float3 background;
 	background.r = background.g = background.b = 1.0f;
 	get_png_background_colour(png_fp, &png_rgb, &background);
 

--- a/src/w2xconv.h
+++ b/src/w2xconv.h
@@ -152,7 +152,7 @@ struct W2XConv {
 	struct W2XConvImpl *impl;
 };
 
-struct float3 {
+struct w2xconv_rgb_float3 {
 	float r;
 	float g;
 	float b;
@@ -161,7 +161,7 @@ struct float3 {
 };
 
 //TODO: what does W2XCONV_EXPORT do?
-W2XCONV_EXPORT	void get_png_background_colour(FILE *png_fp, bool *png_rgb, struct float3 *bkgd_colour);
+W2XCONV_EXPORT	void get_png_background_colour(FILE *png_fp, bool *png_rgb, struct w2xconv_rgb_float3 *bkgd_colour);
 
 W2XCONV_EXPORT const struct W2XConvProcessor *w2xconv_get_processor_list(int *ret_num);
 


### PR DESCRIPTION
Cuda 9.0 dropped sm_20 compute capability so it'll
refuse to compile on cuda 9.0 unless it disables this.
This commit disables compute 20 on Cuda 9.0+.